### PR TITLE
Add typist loop component

### DIFF
--- a/src/components/TypistLoop/index.tsx
+++ b/src/components/TypistLoop/index.tsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import Typist from 'react-typist';
+
+import 'react-typist/dist/Typist.css';
+import './style.less';
+
+interface Props {
+  words: string[];
+}
+
+const TypistLoop: React.FC<Props> = ({ words }) => {
+  const [typing, setTyping] = useState(true);
+  const doneTyping = () => {
+    setTyping(false);
+  };
+  useEffect(() => {
+    setTyping(true);
+  }, [typing]);
+
+  return (
+    <div className="TypistLoop">
+      {typing ? (
+        <Typist
+          cursor={{
+            show: true,
+            blink: true,
+            hideWhenDone: true,
+            hideWhenDoneDelay: 1000,
+          }}
+          onTypingDone={doneTyping}>
+          <Typist.Delay ms={1000} />
+          {words.map((word: string) => (
+            <div>
+              <p className="text">{` ${word}`}</p>
+              <Typist.Backspace count={word.length} delay={1500} />
+              <Typist.Delay ms={1000} />
+            </div>
+          ))}
+        </Typist>
+      ) : (
+        ''
+      )}
+    </div>
+  );
+};
+
+export default TypistLoop;

--- a/src/components/TypistLoop/style.less
+++ b/src/components/TypistLoop/style.less
@@ -1,0 +1,18 @@
+@import './../../styles/base.less';
+
+.TypistLoop {
+  height: 1.5rem;
+  .Typist {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    .Cursor {
+      font-size: 1.5rem;
+    }
+  }
+  .text {
+    line-height: 1.5rem;
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
Adds typing loop component. Syntax is pretty simple:
```javascript
<TypistLoop words={['string1', 'string2', 'string3']} />
```